### PR TITLE
[26기 옥원철 ][Nav] Add: SearchBar 레이아웃 추가 및 버튼별 링크 구현, 충돌 해결

### DIFF
--- a/public/data/ProductCardList.json
+++ b/public/data/ProductCardList.json
@@ -4,7 +4,7 @@
       {
         "id": 1,
         "image_url": "https://images.unsplash.com/photo-1491553895911-0055eca6402d?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1760&q=80",
-        "brand": "NIke",
+        "brand": "Nike",
         "en_name": "Nike Dunk Low Retro Black",
         "ko_name": "나이키 덩크 로우 레트로 블랙",
         "buy_now_price": 284000,
@@ -13,7 +13,7 @@
       {
         "id": 2,
         "image_url": "https://images.unsplash.com/photo-1491553895911-0055eca6402d?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1760&q=80",
-        "brand": "NIke",
+        "brand": "Nike",
         "en_name": "Nike Sakai",
         "ko_name": "나이키 사카이",
         "buy_now_price": 400000,
@@ -22,8 +22,8 @@
       {
         "id": 3,
         "image_url": "https://images.unsplash.com/photo-1491553895911-0055eca6402d?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1760&q=80",
-        "brand": "Jordon",
-        "en_name": "Jordon6 camain retro",
+        "brand": "Jordan",
+        "en_name": "Jordan6 camain retro",
         "ko_name": "조던6 카마인 레트로",
         "buy_now_price": 364000,
         "fast_shipping": true
@@ -40,7 +40,7 @@
       {
         "id": 5,
         "image_url": "https://images.unsplash.com/photo-1491553895911-0055eca6402d?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1760&q=80",
-        "brand": "NIke",
+        "brand": "Nike",
         "en_name": "Nike Dunk Low Retro Black",
         "ko_name": "나이키 덩크 로우 레트로 블랙",
         "buy_now_price": 284000,
@@ -49,7 +49,7 @@
       {
         "id": 6,
         "image_url": "https://images.unsplash.com/photo-1491553895911-0055eca6402d?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1760&q=80",
-        "brand": "NIke",
+        "brand": "Nike",
         "en_name": "Nike Sakai",
         "ko_name": "나이키 사카이",
         "buy_now_price": 400000,
@@ -67,8 +67,8 @@
       {
         "id": 8,
         "image_url": "https://images.unsplash.com/photo-1491553895911-0055eca6402d?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1760&q=80",
-        "brand": "Jordon",
-        "en_name": "Jordon6 camain retro",
+        "brand": "Jordan",
+        "en_name": "Jordan6 camain retro",
         "ko_name": "조던6 카마인 레트로",
         "buy_now_price": 364000,
         "fast_shipping": true

--- a/src/Router.js
+++ b/src/Router.js
@@ -12,14 +12,14 @@ import Redirect from './components/KakaoLogin/Redirect';
 
 function Router() {
   return (
-    <>
+    <BrowserRouter>
       <Nav />
       <BrowserRouter>
         <Routes>
           <Route path="/login" element={<Login />} />
+          <Route path="/main" element={<Main />} />
           <Route path="/main" element={<Redirect />} />
           {/* <Route path="/users/signin" element={<Redirect />} /> */}
-          <Route path="/main" element={<Main />} />
           <Route path="/detail" element={<ProductDetail />} />
           <Route path="/shop" element={<Shop />} />
           <Route path="/order" element={<Order />} />
@@ -27,7 +27,7 @@ function Router() {
         </Routes>
       </BrowserRouter>
       <Footer />
-    </>
+    </BrowserRouter>
   );
 }
 export default Router;

--- a/src/components/Nav/BrandList.js
+++ b/src/components/Nav/BrandList.js
@@ -1,0 +1,34 @@
+const BrandList = [
+  {
+    id: 1,
+    ko_name: '나이키',
+    en_name: 'Nike',
+    url: 'https://cdn.pixabay.com/photo/2012/12/21/10/07/sneakers-71623_1280.jpg',
+  },
+  {
+    id: 2,
+    ko_name: '컨버스',
+    en_name: 'Converse',
+    url: 'https://cdn.pixabay.com/photo/2016/06/03/17/35/shoes-1433925_1280.jpg',
+  },
+  {
+    id: 3,
+    ko_name: '반스',
+    en_name: 'Vans',
+    url: 'https://images.unsplash.com/photo-1565299999261-28ba859019bb?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=774&q=80',
+  },
+  {
+    id: 4,
+    ko_name: '조던',
+    en_name: 'Jordan',
+    url: 'https://images.unsplash.com/photo-1593081891731-fda0877988da?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=774&q=80',
+  },
+  {
+    id: 5,
+    ko_name: '디올',
+    en_name: 'Dior',
+    url: 'https://images.unsplash.com/photo-1614521911663-21d88bd0714a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=870&q=80',
+  },
+];
+
+export default BrandList;

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -1,0 +1,103 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router';
+import styled from 'styled-components';
+import SearchBar from './SearchBar';
+import { BiSearch } from 'react-icons/bi';
+
+export default function Nav() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  const searchToggle = () => {
+    setIsVisible(isVisible ? false : true);
+  };
+
+  const navigate = useNavigate();
+
+  const moveToMain = () => {
+    navigate('/main');
+  };
+  const moveToLogin = () => {
+    navigate('/login');
+  };
+  const moveToShop = () => {
+    navigate('/shop');
+  };
+  const moveToStyle = () => {
+    navigate('/style');
+  };
+
+  return (
+    <Container>
+      {isVisible && (
+        <SearchBar isVisible={isVisible} searchToggle={searchToggle} />
+      )}
+      <LinkBtnSection>
+        <LinkBtn small>고객센터</LinkBtn>
+        <LinkBtn small>관심상품</LinkBtn>
+        <LinkBtn small>마이페이지</LinkBtn>
+        <LinkBtn small onClick={moveToLogin}>
+          로그인
+        </LinkBtn>
+      </LinkBtnSection>
+      <TitleLinks>
+        <Title onClick={moveToMain}>WeSell</Title>
+
+        <TitleLinkBtnSection>
+          <LinkBtn onClick={moveToStyle}>STYLE</LinkBtn>
+          <LinkBtn onClick={moveToShop}>SHOP</LinkBtn>
+          <LinkBtn>ABOUT</LinkBtn>
+          <LinkBtn onClick={searchToggle}>
+            <BiSearch size="20" />
+          </LinkBtn>
+        </TitleLinkBtnSection>
+      </TitleLinks>
+    </Container>
+  );
+}
+
+const Container = styled.nav`
+  position: fixed;
+  z-index: 998;
+  width: 100%;
+  background-color: white;
+`;
+
+const LinkBtnSection = styled.div`
+  display: flex;
+  height: 34px;
+  justify-content: right;
+  align-items: center;
+  border-bottom: 1px solid lightgray;
+`;
+
+const LinkBtn = styled.span`
+  ${props =>
+    props.small
+      ? `margin-right: 30px;
+  color: gray;
+  font-size: 12px;`
+      : `margin-left: 40px;
+  font-size: 15px;`}
+  cursor: pointer;
+`;
+
+const TitleLinks = styled.div`
+  position: relative;
+  display: flex;
+  height: 68px;
+  align-items: center;
+  border-bottom: 1px solid lightgray;
+`;
+
+const Title = styled.span`
+  margin-left: 40px;
+  font: italic bold 32px 'Russo One', sans-serif;
+  cursor: pointer;
+`;
+
+const TitleLinkBtnSection = styled.div`
+  position: absolute;
+  right: 40px;
+  display: flex;
+  align-items: center;
+`;

--- a/src/components/Nav/RecentSearch.js
+++ b/src/components/Nav/RecentSearch.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import styled from 'styled-components';
+import { GiCancel } from 'react-icons/gi';
+
+const RecentSearch = ({ keywordList, reset }) => {
+  return (
+    <Container>
+      <Title>
+        최근 검색어
+        <ResetBtn>
+          <GiCancel onClick={reset} />
+        </ResetBtn>
+      </Title>
+
+      <RecentKeywords>
+        {keywordList.map((keyword, idx) => {
+          return <EachKeyword key={idx}>{keyword}</EachKeyword>;
+        })}
+      </RecentKeywords>
+    </Container>
+  );
+};
+
+const Container = styled.div``;
+
+const Title = styled.span`
+  display: flex;
+  margin: 10px 0;
+  font-size: 12px;
+  font-weight: bold;
+`;
+
+const ResetBtn = styled.span`
+  margin-left: 10px;
+  cursor: pointer;
+`;
+
+const RecentKeywords = styled.ul`
+  width: 700px;
+  list-style: none;
+`;
+
+const EachKeyword = styled.li`
+  margin: 15px 5px;
+  color: gray;
+  font-size: 14px;
+`;
+
+export default RecentSearch;

--- a/src/components/Nav/SearchBar.js
+++ b/src/components/Nav/SearchBar.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import { useState } from 'react';
+import { useNavigate } from 'react-router';
+import styled from 'styled-components';
+import RecentSearch from './RecentSearch';
+import SearchByBrand from './SearchByBrand';
+
+const SearchBar = ({ searchToggle }) => {
+  const [keyword, setKeyword] = useState('');
+  const [keywordList, setKeywordList] = useState([]);
+  const navigate = useNavigate();
+
+  const inputKeyword = e => {
+    setKeyword(e.target.value);
+  };
+
+  const storeKeyword = e => {
+    if (e.key === 'Enter') {
+      setKeywordList([...keywordList, keyword]);
+      setKeyword('');
+      navigate(`/products?keyword=${keyword}`);
+    }
+  };
+
+  const resetKeyword = () => {
+    setKeyword('');
+    setKeywordList([]);
+  };
+
+  return (
+    <Container>
+      <InputSearchWrap>
+        <InputSearch
+          placeholder="브랜드명, 모델명, 모델번호 등"
+          onChange={inputKeyword}
+          onKeyPress={storeKeyword}
+          value={keyword}
+        />
+        <Cancel onClick={searchToggle}>취소</Cancel>
+      </InputSearchWrap>
+      <RecentSearch keywordList={keywordList} reset={resetKeyword} />
+      <SearchByBrand />
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: fixed;
+  width: 100%;
+  padding: 30px;
+  background-color: white;
+  z-index: 999;
+  border-bottom: 1px solid gray;
+`;
+
+const InputSearchWrap = styled.div`
+  margin: 10px 0px;
+`;
+
+const InputSearch = styled.input`
+  width: 700px;
+  height: 40px;
+  padding: 0px 20px;
+  color: rgb(34, 34, 34);
+  background-color: #f4f4f4;
+  border: none;
+  font-size: 14px;
+`;
+
+const Cancel = styled.span`
+  margin: 0px 10px;
+  font-size: 14px;
+  cursor: pointer;
+`;
+
+export default SearchBar;

--- a/src/components/Nav/SearchByBrand.js
+++ b/src/components/Nav/SearchByBrand.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { useNavigate } from 'react-router';
+import styled from 'styled-components';
+import BrandList from './BrandList';
+
+export default function SearchByBrand() {
+  const navigate = useNavigate();
+
+  return (
+    <Container>
+      {BrandList.map(brand => (
+        <BrandWrap key={brand.id}>
+          <Image
+            src={brand.url}
+            alt={brand.en_name}
+            onClick={() => navigate(`/products?keyword=${brand.en_name}`)}
+          />
+          <Name onClick={() => navigate(`/products?keyword=${brand.en_name}`)}>
+            {brand.en_name}
+          </Name>
+        </BrandWrap>
+      ))}
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+`;
+
+const BrandWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 5px 20px;
+`;
+
+const Image = styled.img`
+  width: 70px;
+  height: 70px;
+  cursor: pointer;
+`;
+
+const Name = styled.div`
+  font-size: 13px;
+  font-weight: bold;
+  cursor: pointer;
+`;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- `useNavigate` Hook 을 사용하여 링크 버튼 라우팅
- 검색바 레이아웃 작성 및 검색어 입력에 따른 검색창 url로 이동

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
### 1. 링크 버튼 라우팅
- `useNavigate` Hook을 사용하여 Nav 우측 버튼에 링크 이동 기능 부여

### 2. 검색바 레이아웃 작성
- `useState` Hook 활용하여 검색바 토글 기능 구현( 돋보기 버튼 - 검색바 활성화 / 취소 버튼 - 검색바 비활성화)
- 검색어 입력 후 엔터키를 누를 때 최근 검색어가 아래에 노출
- '최근 검색어' 옆 x버튼 클릭 시 최근 검색어 삭제

### 3. 브랜드별 검색 기능
- 검색바 하단 브랜드 이미지 또는 브랜드 네임 클릭시 해당 브랜드를 필터링하여 보여주는 query parameter로 이동하는 로직
- 추후 B/E 와 통신 예정


<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- React Router v6 업데이트에 따라 `useNavigate` Hook을 사용해보았습니다.
- `useState`를 활용하여 토글 기능을 구현해보았습니다.

<br />

## :: 기타 질문 및 특이 사항
- 
