### PR TITLE
[26기 옥원철] Modified: [Order] 구매, 판매 페이지 리뷰 반영 및 컴포넌트 재사용

### DIFF
--- a/public/data/OrderMockData.json
+++ b/public/data/OrderMockData.json
@@ -1,0 +1,89 @@
+{
+  "result": {
+    "lowest_price_by_size": [
+      {
+        "bid_type": "Buy",
+        "sizes": [
+          {
+            "id": 11,
+            "lowest_price": 279000,
+            "size": "230"
+          },
+          {
+            "id": 12,
+            "lowest_price": 243000,
+            "size": "240"
+          },
+          {
+            "id": 13,
+            "lowest_price": 1270000,
+            "size": "250"
+          },
+          {
+            "id": 14,
+            "lowest_price": 3240000,
+            "size": "260"
+          },
+          {
+            "id": 15,
+            "lowest_price": 870000,
+            "size": "270"
+          }
+        ]
+      },
+      {
+        "bid_type": "Sell",
+        "sizes": [
+          {
+            "id": 11,
+            "lowest_price": 286000,
+            "size": "230"
+          },
+          {
+            "id": 12,
+            "lowest_price": 257000,
+            "size": "240"
+          },
+          {
+            "id": 13,
+            "lowest_price": 1350000,
+            "size": "250"
+          },
+          {
+            "id": 14,
+            "lowest_price": 3520000,
+            "size": "260"
+          },
+          {
+            "id": 15,
+            "lowest_price": 930000,
+            "size": "270"
+          }
+        ]
+      }
+    ],
+    "market_price": [],
+    "order_history": [],
+    "product_image": [
+      {
+        "id": 5,
+        "url": "https://github.com/Gyubs/django_setting_prcatice/blob/main/12_1.jpg?raw=true"
+      },
+      {
+        "id": 6,
+        "url": "https://github.com/Gyubs/django_setting_prcatice/blob/main/12_2.jpg?raw=true"
+      }
+    ],
+    "product_info": {
+      "brand": "Nike",
+      "color": "WHITE/BLACK",
+      "en_name": "Nike Dunk Low Retro Black",
+      "fast_shipping": true,
+      "id": 3,
+      "ko_name": "나이키 덩크 로우 레트로 블랙",
+      "model_number": "DD1391-100",
+      "release_date": "2021-01-14",
+      "release_price": 119000
+    }
+  }
+}

--- a/src/Router.js
+++ b/src/Router.js
@@ -5,6 +5,8 @@ import Shop from './pages/Shop/Shop';
 import Nav from './components/Nav/Nav';
 import Footer from './components/Footer';
 import Login from './pages/LoginRegister/Login';
+import Order from './pages/Order/Order';
+import OrderDetail from './pages/Order/OrderDetail';
 
 function Router() {
   return (
@@ -16,6 +18,10 @@ function Router() {
         <Route path="/users/signin" element={<Main />} />
         <Route path="/detail" element={<ProductDetail />} />
         <Route path="/products" element={<Shop />} />
+        <Route path="/buy" element={<Order type="buy" />} />
+        <Route path="/sell" element={<Order type="sell" />} />
+        <Route path="/buy/detail" element={<OrderDetail type="buy" />} />
+        <Route path="/sell/detail" element={<OrderDetail type="sell" />} />
       </Routes>
       <Footer />
     </BrowserRouter>

--- a/src/pages/Main/MainSlider/SlideData.js
+++ b/src/pages/Main/MainSlider/SlideData.js
@@ -30,3 +30,5 @@ const slideData = [
     subtitle: '나이키와 원철과 언더커버의 콜라보',
   },
 ];
+
+export default slideData;

--- a/src/pages/Order/BidDeadline.js
+++ b/src/pages/Order/BidDeadline.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import { useState } from 'react';
+import styled from 'styled-components';
+
+const daysList = [
+  { id: 1, day: 1 },
+  { id: 2, day: 3 },
+  { id: 3, day: 7 },
+  { id: 4, day: 30 },
+  { id: 5, day: 60 },
+];
+
+export default function BidDeadline() {
+  const [daysLeft, setDaysLeft] = useState(30);
+
+  const changeDeadline = e => {
+    setDaysLeft(e.target.name);
+  };
+
+  return (
+    <Container>
+      <Title>입찰 마감기한</Title>
+      <Deadline>{daysLeft}일</Deadline>
+      <DaysLeftWrap>
+        {daysList.map(day => {
+          return (
+            <DaysLeft
+              key={day.id}
+              name={day.day}
+              onClick={changeDeadline}
+              selected={day.day === daysLeft}
+            >
+              {day.day}일
+            </DaysLeft>
+          );
+        })}
+      </DaysLeftWrap>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  width: 100%;
+  margin: 20px 0;
+`;
+
+const Title = styled.div`
+  margin-bottom: 10px;
+`;
+
+const Deadline = styled.div``;
+
+const DaysLeftWrap = styled.div`
+  display: flex;
+  justify-content: space-around;
+`;
+
+const DaysLeft = styled.button`
+  text-align: center;
+  width: 110px;
+  height: 42px;
+  padding: 13px 0;
+  margin: 10px 5px;
+  background-color: white;
+  border: 1px solid lightgray;
+  border-radius: 12px;
+  cursor: pointer;
+  &:hover {
+    background-color: #ebebeb;
+  }
+  &:focus {
+    border: 1px solid black;
+    font-weight: bold;
+  }
+`;

--- a/src/pages/Order/Order.js
+++ b/src/pages/Order/Order.js
@@ -1,39 +1,106 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router';
 import styled from 'styled-components';
+import ShoesInfo from './ShoesInfo';
+import orderType from './orderType';
 
-export default function Order() {
+const { buy, sell } = orderType;
+
+export default function Order({ type }) {
+  const [productList, setProductList] = useState({});
+
+  useEffect(() => {
+    fetch('/data/OrderMockData.json')
+      .then(res => res.json())
+      .then(data => {
+        setProductList(data.result);
+      });
+  }, []);
+
+  const navigate = useNavigate();
+
+  const moveToOrderDetail = () => {
+    navigate(type === buy ? `/${buy}/detail` : `/${sell}/detail`);
+  };
+
   return (
-    <Wrapper>
-      <TitleWrapper>
-        <Title>구매하기</Title>
-      </TitleWrapper>
-      <ContentWrapper>
-        <ProductWrapper />
-      </ContentWrapper>
-    </Wrapper>
+    <Container>
+      <OrderWrap>
+        <Title>{type === buy ? '구매하기' : '판매하기'}</Title>
+        <ShoesInfo />
+        <SizeListGrid>
+          {productList.lowest_price_by_size &&
+            (type === buy
+              ? productList.lowest_price_by_size[0].sizes.map(list => (
+                  <LinkBtn key={list.id} onClick={moveToOrderDetail}>
+                    <Size>{list.size}</Size>
+                    <Price isBuy>{list.lowest_price}</Price>
+                  </LinkBtn>
+                ))
+              : productList.lowest_price_by_size[1].sizes.map(list => (
+                  <LinkBtn key={list.id} onClick={moveToOrderDetail}>
+                    <Size>{list.size}</Size>
+                    <Price>{list.lowest_price}</Price>
+                  </LinkBtn>
+                )))}
+        </SizeListGrid>
+      </OrderWrap>
+    </Container>
   );
 }
-const Wrapper = styled.div`
-  margin-top: 40px;
+
+const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  padding-top: 120px;
 `;
 
-const TitleWrapper = styled.div`
-  text-align: center;
-  margin-bottom: 40px;
+const OrderWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 50px;
+  margin: 70px 0px;
+  width: 700px;
+  height: 400px;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
 `;
 
-const Title = styled.span`
-  font-size: 1.5em;
+const Title = styled.div`
+  margin-bottom: 10px;
+  font-size: 20px;
   font-weight: bold;
 `;
 
-const ContentWrapper = styled.div`
-  overflow: hidden;
-  max-width: 780px;
-  min-height: 900px;
-  margin: 0 auto;
-  padding: 20px 40px 160px;
-  background-color: silver;
+const SizeListGrid = styled.div`
+  display: grid;
+  justify-items: center;
+  grid-template-columns: repeat(3, 1fr);
+  grid-gap: 10px;
 `;
 
-const ProductWrapper = styled.div``;
+const LinkBtn = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 200px;
+  height: 60px;
+  background-color: white;
+  border: 0.5px solid lightgray;
+  border-radius: 10px;
+  cursor: pointer;
+  &:active {
+    border: 1px solid black;
+  }
+`;
+
+const Size = styled.div`
+  color: gray;
+  margin-bottom: 3px;
+`;
+
+const Price = styled.div`
+  ${props => (props.isBuy ? 'color: red' : 'color: #41B978')};
+  font-size: 14px;
+`;

--- a/src/pages/Order/OrderDetail.js
+++ b/src/pages/Order/OrderDetail.js
@@ -1,0 +1,142 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import OrderHow from './OrderHow';
+import ShoesInfo from './ShoesInfo';
+import orderType from './orderType';
+
+const { buy, buyNow, sellNow, bid } = orderType;
+
+export default function OrderDetail({ type }) {
+  const [title, setTitle] = useState(type === buy ? buyNow : sellNow);
+  const [shoeInfo, setShoeInfo] = useState([]);
+
+  useEffect(() => {
+    fetch('/data/OrderMockData.json')
+      .then(res => res.json())
+      .then(data => {
+        setShoeInfo(data.result.lowest_price_by_size);
+      });
+  }, []);
+
+  const changeToOrderNow = () => {
+    setTitle(type === buy ? buyNow : sellNow);
+  };
+
+  const changeToBid = () => {
+    setTitle(bid);
+  };
+
+  return (
+    <Container>
+      <OrderWrap>
+        <Title>{title}하기</Title>
+        <ShoesInfo />
+        <PriceInfo>
+          <PriceNow>
+            <PriceTitle> {buyNow}가 </PriceTitle>
+            {shoeInfo[0] && shoeInfo[0].sizes[0].lowest_price} 원
+          </PriceNow>
+          <CenterLine />
+          <PriceNow>
+            <PriceTitle> {sellNow}가 </PriceTitle>
+            {shoeInfo[0] && shoeInfo[1].sizes[0].lowest_price} 원
+          </PriceNow>
+        </PriceInfo>
+        <ButtonWrap>
+          <OrderTypeButton
+            isBidOrOrder={title === buyNow || title === sellNow}
+            onClick={changeToBid}
+            isBuy={type === buy}
+          >
+            {bid}
+          </OrderTypeButton>
+          <OrderTypeButton
+            isBidOrOrder={title === bid}
+            onClick={changeToOrderNow}
+          >
+            {type === buy ? buyNow : sellNow}
+          </OrderTypeButton>
+        </ButtonWrap>
+        <OrderHow
+          title={title}
+          orderNowPrice={
+            shoeInfo[0] &&
+            (type === buy
+              ? shoeInfo[0].sizes[0].lowest_price
+              : shoeInfo[1].sizes[0].lowest_price)
+          }
+        />
+      </OrderWrap>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  padding: 120px;
+`;
+
+const OrderWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 50px 50px;
+  margin: 70px 0px;
+  width: 700px;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
+`;
+
+const Title = styled.div`
+  margin-bottom: 10px;
+  font-size: 20px;
+  font-weight: bold;
+`;
+
+const PriceInfo = styled.div`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  padding: 20px 0;
+  border-top: 1px solid #ebebeb;
+`;
+
+const PriceTitle = styled.p`
+  margin-bottom: 5px;
+  color: gray;
+  font-weight: lighter;
+  font-size: 14px;
+`;
+
+const PriceNow = styled.div`
+  text-align: center;
+  width: 40%;
+`;
+
+const CenterLine = styled.div`
+  height: 100%;
+  border-right: 1px solid #ebebeb;
+`;
+
+const ButtonWrap = styled.div`
+  display: flex;
+  width: 100%;
+  height: 50px;
+  border-radius: 80px;
+  background-color: #f4f4f4;
+`;
+
+const OrderTypeButton = styled.div`
+  text-align: center;
+  vertical-align: middle;
+  width: 50%;
+  height: 40px;
+  padding: 12px 0;
+  margin: 5px 5px;
+  border-radius: 80px;
+  cursor: pointer;
+  ${props =>
+    props.isBidOrOrder
+      ? 'background-color: #f4f4f4'
+      : 'color: white; background-color: #ef6253;'}
+`;

--- a/src/pages/Order/OrderHow.js
+++ b/src/pages/Order/OrderHow.js
@@ -1,0 +1,101 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import BidDeadline from './BidDeadline';
+import SubmitPrice from './SubmitPrice';
+import orderType from './orderType';
+
+const { buyNow, sellNow, bid } = orderType;
+
+export default function OrderHow({ title, orderNowPrice }) {
+  const [bidPrice, setBidPrice] = useState();
+
+  const bidding = e => {
+    setBidPrice(e.target.value);
+  };
+
+  return (
+    <Container>
+      <PriceInputWrap>
+        <Title>{title}가</Title>
+        {(title === buyNow || title === sellNow) && (
+          <Price>{orderNowPrice}원</Price>
+        )}
+        {title === bid && (
+          <PriceInput
+            placeholder="희망가 입력"
+            value={bidPrice}
+            onChange={bidding}
+          />
+        )}
+        {title === bid && <Won>원</Won>}
+      </PriceInputWrap>
+      <ChargeWrap>
+        <ChargeType> 검수비 </ChargeType>
+        <ChargePrice> 무료 </ChargePrice>
+      </ChargeWrap>
+      <ChargeWrap>
+        <ChargeType> 배송비 </ChargeType>
+        <ChargePrice> 무료 </ChargePrice>
+      </ChargeWrap>
+      {title === bid && <BidDeadline />}
+      <SubmitPrice
+        title={title}
+        orderNowPrice={orderNowPrice}
+        bidPrice={bidPrice}
+      />
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  width: 100%;
+  margin: 20px 0;
+`;
+
+const PriceInputWrap = styled.div`
+  margin-bottom: 10px;
+  padding-bottom: 10px;
+  border-bottom: 2px solid lightgray;
+`;
+
+const Title = styled.div``;
+
+const Price = styled.div`
+  text-align: end;
+  font-size: 1.4rem;
+  font-weight: bold;
+`;
+
+const PriceInput = styled.input`
+  text-align: end;
+  width: 96%;
+  height: 22px;
+  font-size: 1.4rem;
+  font-weight: bold;
+  border: none;
+  &:focus {
+    outline: none;
+  }
+  &::placeholder {
+    color: lightgray;
+  }
+`;
+
+const Won = styled.span`
+  text-align: end;
+  font-size: 1.4rem;
+  font-weight: bold;
+`;
+
+const ChargeWrap = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const ChargeType = styled.div`
+  margin-bottom: 10px;
+  color: gray;
+  font-weight: lighter;
+`;
+
+const ChargePrice = styled.div``;

--- a/src/pages/Order/ShoesInfo.js
+++ b/src/pages/Order/ShoesInfo.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { useState, useEffect } from 'react';
+import styled from 'styled-components';
+
+export default function ShoesInfo() {
+  const [shoeInfo, setShoeInfo] = useState({});
+
+  useEffect(() => {
+    fetch('/data/OrderMockData.json')
+      .then(res => res.json())
+      .then(data => {
+        setShoeInfo(data.result);
+      });
+  }, []);
+
+  return (
+    <Container>
+      <ShoesImage
+        src={shoeInfo.product_image && shoeInfo.product_image[0].url}
+        alt="Shoes Image"
+      />
+      {shoeInfo.product_info && (
+        <DetailInfo>
+          <ModelNumber>{shoeInfo.product_info.model_number}</ModelNumber>
+          <EngName>{shoeInfo.product_info.en_name}</EngName>
+          <KorName>{shoeInfo.product_info.ko_name}</KorName>
+        </DetailInfo>
+      )}
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  margin: 20px 0;
+`;
+
+const ShoesImage = styled.img`
+  width: 80px;
+  height: 80px;
+`;
+
+const DetailInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin-left: 10px;
+`;
+
+const ModelNumber = styled.div`
+  font-weight: bold;
+  margin-bottom: 5px;
+`;
+
+const EngName = styled.div`
+  font-size: 14px;
+  margin-bottom: 5px;
+`;
+
+const KorName = styled.div`
+  color: lightgray;
+  font-size: 13px;
+`;

--- a/src/pages/Order/SubmitPrice.js
+++ b/src/pages/Order/SubmitPrice.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import styled from 'styled-components';
+import orderType from './orderType';
+
+const { buyNow, sellNow, bid } = orderType;
+
+export default function SubmitPrice({ title, orderNowPrice, bidPrice }) {
+  return (
+    <Container>
+      <PriceInputWrap>
+        <Title> 총 결제금액 </Title>
+        {(title === buyNow || title === sellNow) && (
+          <Price>{orderNowPrice}원</Price>
+        )}
+        {title === bid && <Price>{bidPrice}원</Price>}
+      </PriceInputWrap>
+      <SubmitBtn> {title} 계속 </SubmitBtn>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  width: 100%;
+  margin: 20px 0;
+`;
+
+const PriceInputWrap = styled.div`
+  margin-bottom: 10px;
+  padding-bottom: 10px;
+  border-bottom: 2px solid lightgray;
+`;
+
+const Title = styled.div``;
+
+const Price = styled.div`
+  text-align: end;
+  font-size: 1.4rem;
+  font-weight: bold;
+`;
+
+const SubmitBtn = styled.button`
+  width: 100%;
+  height: 52px;
+  color: white;
+  background-color: black;
+  border: none;
+  border-radius: 12px;
+  font-size: 20px;
+  cursor: pointer;
+`;

--- a/src/pages/Order/orderType.js
+++ b/src/pages/Order/orderType.js
@@ -1,0 +1,9 @@
+const orderType = {
+  buy: 'buy',
+  sell: 'sell',
+  buyNow: '즉시 구매',
+  sellNow: '즉시 판매',
+  bid: '구매 입찰',
+};
+
+export default orderType;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [x] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 구매하기, 판매하기 페이지 레이아웃 작성

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

### 1. 구매하기/판매하기 페이지 레이아웃 작성
- 컴포넌트 재사용을 통한 구매하기/판매하기 페이지 작성
- 구매 입찰 / 즉시 구매(판매) 선택에 따라 페이지 레이아웃 변경
- 구매(판매) 입찰 시 구매(판매) 희망가를 입력하고, 입찰 마감기한을 설정
- 즉시 구매(판매) 시 즉시 구매(판매)가에 따라 결제

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 구매(판매) 조건(입찰 / 즉시결제)에 따른 조건부 렌더링을 적용해보았습니다.

<br />

## :: 기타 질문 및 특이 사항
- 구매(판매) 입찰 시 입찰 마감기한을 계산하는 로직을 작성 중입니다.
- 현재 mock data로 작성된 부분은 백엔드 통신을 통해서 데이터를 호출할 예정입니다. 
